### PR TITLE
Update MonoMod dependency

### DIFF
--- a/CelesteMod/Source/CelesteMod-core.csproj
+++ b/CelesteMod/Source/CelesteMod-core.csproj
@@ -17,7 +17,7 @@
 
     <ItemGroup>
         <PackageReference Include="BepInEx.AssemblyPublicizer.MSBuild" Version="0.4.1" PrivateAssets="all" />
-        <PackageReference Include="MonoModReorg.RuntimeDetour" Version="23.3.22.1" PrivateAssets="all" ExcludeAssets="runtime" />
+        <PackageReference Include="MonoMod.RuntimeDetour" Version="25.0.2" PrivateAssets="all" ExcludeAssets="runtime" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
The MonoModReorg packages were a temporary solution and are no longer updated, the main MonoMod packages are on reorg now.