### PR TITLE
Remove level-specific hooks

### DIFF
--- a/CelesteMod/.template.config/template.json
+++ b/CelesteMod/.template.config/template.json
@@ -22,11 +22,6 @@
       "datatype": "bool",
       "defaultValue": "false"
     },
-    "Hooks": {
-      "type": "parameter",
-      "datatype": "bool",
-      "defaultValue": "false"
-    },
     "Settings": {
       "type": "parameter",
       "datatype": "bool",

--- a/CelesteMod/Source/CelesteModModule.cs
+++ b/CelesteMod/Source/CelesteModModule.cs
@@ -43,43 +43,11 @@ namespace Celeste.Mod.CelesteMod {
             typeof(CelesteModExports).ModInterop(); // TODO: delete this line if you do not need to export any functions
 
 #endif
-#if Hooks
-            On.Celeste.LevelLoader.ctor += LevelLoader_ctor;
-            On.Celeste.OverworldLoader.ctor += OverworldLoader_ctor;
-
-#endif
             // TODO: apply any hooks that should always be active
         }
 
         public override void Unload() {
-#if Hooks
-            On.Celeste.LevelLoader.ctor -= LevelLoader_ctor;
-            On.Celeste.OverworldLoader.ctor -= OverworldLoader_ctor;
-
-#endif
             // TODO: unapply any hooks applied in Load()
         }
-#if Hooks
-
-        public void LoadBeforeLevel() {
-            // TODO: apply any hooks that should only be active while a level is loaded
-        }
-
-        public void UnloadAfterLevel() {
-            // TODO: unapply any hooks applied in LoadBeforeLevel()
-        }
-
-        private void OverworldLoader_ctor(On.Celeste.OverworldLoader.orig_ctor orig, OverworldLoader self, Overworld.StartMode startmode, HiresSnow snow) {
-            orig(self, startmode, snow);
-            if (startmode != (Overworld.StartMode) (-1)) {
-                UnloadAfterLevel();
-            }
-        }
-
-        private void LevelLoader_ctor(On.Celeste.LevelLoader.orig_ctor orig, LevelLoader self, Session session, Vector2? startposition) {
-            orig(self, session, startposition);
-            LoadBeforeLevel();
-        }
-#endif
     }
 }

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ This will create a solution for your mod and a series of classes in the namespac
 Available parameters:
 * `--Samples`: Creates a set of sample entities and triggers, including Ahorn and Lönn plugins. (Defaults to false)
 * `--Exports`: Includes a static class for use with `MonoMod.ModInterop`. (Defaults to false)
-* `--Hooks` : Generates a series of helper methods for loading and unloading hooks on level load rather than just on mod load. (Defaults to false)
 * `--Settings` : Includes a blank `EverestModuleSettings` class and configures the module to look for it. (Defaults to true)
 * `--Session` : Includes a blank `EverestModuleSession` class and configures the module to look for it. (Defaults to true)
 * `--SaveData` : Includes a blank `EverestModuleSaveData` class and configures the module to look for it. (Defaults to true)


### PR DESCRIPTION
This pattern can create double hooks because there are ways to exit a level other than the OverworldLoader. Maybe a revised version of this can be readded eventually, but level-specific hooks are pretty niche and a broken version is worse than no version.