### PR TITLE
Include pdb in GitHub artifact

### DIFF
--- a/CelesteMod/.github/workflows/dotnet-core.yml
+++ b/CelesteMod/.github/workflows/dotnet-core.yml
@@ -39,6 +39,7 @@ jobs:
         path: |
           everest.yaml
           bin/CelesteMod.dll
+          bin/CelesteMod.pdb
 #if Samples
           Ahorn/**/*
           Audio/**/*


### PR DESCRIPTION
Allows line numbers in crash logs for automated release builds.