### PR TITLE
Make Everest ignore the Source folder

### DIFF
--- a/CelesteMod/.everestignore
+++ b/CelesteMod/.everestignore
@@ -1,0 +1,2 @@
+# Make Everest ignore the Source folder
+Source/


### PR DESCRIPTION
Self-explanatory, adds a `.everestignore` file to the template which tells Everest to ignore the `Source` folder.
If something's in the `Source` folder then it's likely not supposed to be of interest to Everest.